### PR TITLE
FIX ABANDONED OCEAN

### DIFF
--- a/js/data/homeactions.js
+++ b/js/data/homeactions.js
@@ -1734,7 +1734,7 @@ SharkGame.HomeActions = {
                 resource: {
                     octopus: 1,
                 },
-                upgrade: ["farAbandonedExploration"],
+                upgrade: ["farExploration"],
             },
             outcomes: [
                 "An octopus is a scavenger now.",


### PR DESCRIPTION
Far Exploration is supposed to unlock Octopus Scavenger, which, due to my lack of enough playtesting, it doesn't, making it impossible to complete the Abandoned Ocean. I'm gonna test now if my change right now fixed the issue and will report back.